### PR TITLE
Add H-Orange-S-54 details to the colour page

### DIFF
--- a/guidelines/principles/colors/README.md
+++ b/guidelines/principles/colors/README.md
@@ -93,6 +93,13 @@ The core Blue family serves as the accent color.
 | `Hal-Yellow-D-30`   | #947705      | (48, 93%, 30%)   |
 
 
+#### Orange
+
+| Name                | Value (HEX)  | Value (hsl)      |
+| :---                | :---         | :---             |
+| `H-Orange-S-54`     | #F38F20      | (32, 90%, 54%)   |
+
+
 
 
 ### Color usage tokens


### PR DESCRIPTION
My team has spotted that value details for Orange token are missing from this page - i have been using details from your source XD file stored on github