### PR TITLE
Fixed the sidenav box-shadow bug of the new site

### DIFF
--- a/website/screens/common/sidenav/SidenavComponents.tsx
+++ b/website/screens/common/sidenav/SidenavComponents.tsx
@@ -38,7 +38,8 @@ const StyledLink = styled.a`
   user-select: none;
   min-height: 17px;
   font-size: 14px;
-
+  box-shadow: 0 0 0 2px transparent;
+  
   &:hover {
     background: ${({ selected }: StyledLinkProps) =>
       selected ? "#333333" : "#e6e6e6"};


### PR DESCRIPTION
Sidenav options had a remaining blue line from the `box-shadow` when they lost the focus:

<img width="197" alt="focus_error" src="https://user-images.githubusercontent.com/44321109/157078088-b680fcd4-2f69-49e7-ba6a-84efbce91f0f.png">